### PR TITLE
Fix file:// url to path support for windows

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,10 +1,11 @@
 const fs = require("fs");
 const fetch = require("node-fetch");
+const Url = require("url");
 
 
 module.exports = (url, options) => {
   if (url.startsWith("file://")) {
-    const path = url.match(/file:\/\/(.+)/)[1];
+    const path = Url.fileURLToPath(url);
     const stream = fs.createReadStream(path);
     return new fetch.Response(stream);
   } else {


### PR DESCRIPTION
Fixes: #6 

According to the [node.js docs](https://nodejs.org/api/url.html#url_url_fileurltopath_url), this should work, but I don't have a windows system and I couldn't find a way to fake it to test the changes. @YF1999, could you please test the changes on your computer? I prepared a test, I just ask that you run it.

`package.json`
```json
{
  "scripts": {
    "test": "node test.js"
  },
  "dependencies": {
    "@hyperjump/json-schema": "github:hyperjump-io/json-schema-validator",
    "@hyperjump/json-schema-core": "github:hyperjump-io/json-schema-core#file-url-windows"
  }
}
```

`test.js`
```javascript
const JsonSchema = require("@hyperjump/json-schema");


(async function () {
  await JsonSchema.get(process.argv[2]);
  console.log("It Works!!!");
}());
```

Then run `npm install` and `npm test -- file:///C:/path/to/my/schema/schema.json`